### PR TITLE
fix: update occupancy mapper include path

### DIFF
--- a/src/mapping/occupancy_mapper.cpp
+++ b/src/mapping/occupancy_mapper.cpp
@@ -1,5 +1,5 @@
 // src/occupancy_mapper.cpp
-#include "ekf_slam/occupancy_mapper.hpp"
+#include "mapping/occupancy_mapper.hpp"
 #include <cmath>
 #include <algorithm>
 


### PR DESCRIPTION
## Summary
- correct header include for occupancy mapper implementation

## Testing
- `cmake .. && make -j4` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689163afd3e883209cea9f541d785ffb