### PR TITLE
Refine EKF covariance prediction

### DIFF
--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -44,7 +44,10 @@ void EkfSlamSystem::predict(double v, double delta, double dt)
   Eigen::MatrixXd Fx = Eigen::MatrixXd::Zero(3, mu_.size());
   Fx.block(0,0,3,3) = Eigen::Matrix3d::Identity();
 
-  sigma_ = sigma_ + Fx.transpose() * Gx.transpose() * R * Gx * Fx;
+  Eigen::MatrixXd G_bar = Eigen::MatrixXd::Identity(mu_.size(), mu_.size());
+  G_bar.block<3,3>(0,0) = Gx;
+
+  sigma_ = G_bar * sigma_ * G_bar.transpose() + Fx.transpose() * R * Fx;
 }
 
 // -----------------------------


### PR DESCRIPTION
## Summary
- Expand motion Jacobian into full-state `G_bar` matrix.
- Use `G_bar` to propagate covariance and add control noise term.

## Testing
- `colcon test --packages-select ekf_slam` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: unable to locate package)*
- `cmake -S . -B build` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689163a38f6483208e8c2b27ea16a618