### PR TITLE
Remove RViz from SLAM launch

### DIFF
--- a/launch/slam_launch.py
+++ b/launch/slam_launch.py
@@ -20,12 +20,6 @@ def generate_launch_description():
         description='Path to SLAM configuration file'
     )
 
-    rviz_config_arg = DeclareLaunchArgument(
-        'rviz_config',
-        default_value=PathJoinSubstitution([pkg_share, 'rviz', 'slam_visualization.rviz']),
-        description='Path to RViz configuration file'
-    )
-
     slam_node = Node(
         package='ekf_slam',
         executable='slam_node',
@@ -43,18 +37,8 @@ def generate_launch_description():
         ]
     )
 
-    rviz_node = Node(
-        package='rviz2',
-        executable='rviz2',
-        name='rviz2',
-        arguments=['-d', LaunchConfiguration('rviz_config')],
-        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}]
-    )
-
     return LaunchDescription([
         use_sim_time_arg,
         config_file_arg,
-        rviz_config_arg,
-        slam_node,
-        rviz_node
+        slam_node
     ])


### PR DESCRIPTION
## Summary
- simplify slam launch to start only the EKF SLAM node

## Testing
- `colcon test` *(fails: Has this package been built before?)*
- `colcon build` *(fails: Could not find a package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_689170aa2f448320a98e865d1d809947