### PR TITLE
fix weak_ptr issue on slam node initialization

### DIFF
--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -26,6 +26,9 @@ public:
   SlamNode();
   ~SlamNode();
 
+  // Perform initialization that requires shared_from_this()
+  void initialize();
+
 private:
 
   double noise_x_, noise_y_, noise_theta_;

--- a/src/core/slam_node.cpp
+++ b/src/core/slam_node.cpp
@@ -39,6 +39,11 @@ SlamNode::SlamNode() : Node("ekf_slam_node")
     meas_range_noise_, meas_bearing_noise_, assoc_thresh_
   );
 
+  RCLCPP_INFO(this->get_logger(), "EKF SLAM Node Initialized.");
+}
+
+void SlamNode::initialize()
+{
   // LaserScan 전처리기 초기화
   laser_processor_ = std::make_shared<laser::LaserProcessor>(
     shared_from_this(), tf_buffer_.get(), "base_link");
@@ -53,7 +58,6 @@ SlamNode::SlamNode() : Node("ekf_slam_node")
 
   occupancy_mapper_->startMapping();
 
-
   // LaserScan 구독
   scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
     "/scan", 10, std::bind(&SlamNode::scanCallback, this, std::placeholders::_1));
@@ -67,9 +71,6 @@ SlamNode::SlamNode() : Node("ekf_slam_node")
 
   // 주기적으로 맵 publish (1초 간격)
   map_timer_ = this->create_wall_timer( std::chrono::seconds(1), std::bind(&SlamNode::publishMap, this));
-
-
-  RCLCPP_INFO(this->get_logger(), "EKF SLAM Node Initialized.");
 }
 
 SlamNode::~SlamNode()
@@ -131,6 +132,7 @@ int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<ekf_slam::SlamNode>();
+  node->initialize();
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
## Summary
- avoid calling `shared_from_this()` in `SlamNode` constructor
- add initialization method and call before spinning

## Testing
- `colcon build --event-handlers console_cohesion+ --packages-select ekf_slam` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_6891a5e8af60832085c34a6282f2c5ea