### PR TITLE
fix weak_ptr issue on slam node initialization

### DIFF
--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -26,6 +26,9 @@ public:
   SlamNode();
   ~SlamNode();
 
+  // Perform initialization that requires shared_from_this()
+  void initialize();
+
 private:
 
   double noise_x_, noise_y_, noise_theta_;


### PR DESCRIPTION
## Summary
- avoid calling `shared_from_this()` in `SlamNode` constructor
- add initialization method and call before spinning
- remove unused variable in `ackermannCallback`

## Testing
- `colcon build --event-handlers console_cohesion+ --packages-select ekf_slam` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_6891a5e8af60832085c34a6282f2c5ea