### PR TITLE
Fix slam parameter YAML map nesting

### DIFF
--- a/config/slam_params.yaml
+++ b/config/slam_params.yaml
@@ -10,9 +10,9 @@ ekf_slam:
       bearing: 0.05
     data_association:
       threshold: 5.991
-    scan_downsample: 
+    scan_downsample:
       step: 10
-  map : 
-    width: 1500
-    height: 1500
-    resolution: 0.05
+    map:
+      width: 1500
+      height: 1500
+      resolution: 0.05


### PR DESCRIPTION
## Summary
- nest the map settings beneath `ros__parameters` in `slam_params.yaml`

## Testing
- `python3 - <<'PY'
import yaml
with open('config/slam_params.yaml') as f:
    data=yaml.safe_load(f)
print(data)
PY`
- `colcon test --packages-select ekf_slam` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6893058fbd248320a868e66856a927b3