### PR TITLE
Fix laser scan inversion angle limits

### DIFF
--- a/src/preprocessing/laser_processor.cpp
+++ b/src/preprocessing/laser_processor.cpp
@@ -83,8 +83,10 @@ void LaserProcessor::invertScan(sensor_msgs::msg::LaserScan & scan)
 {
   std::reverse(scan.ranges.begin(), scan.ranges.end());
   std::reverse(scan.intensities.begin(), scan.intensities.end());
-  scan.angle_min = -scan.angle_max;
-  scan.angle_max = -scan.angle_min;
+  double orig_min = scan.angle_min;
+  double orig_max = scan.angle_max;
+  scan.angle_min = -orig_max;
+  scan.angle_max = -orig_min;
   scan.angle_increment = -scan.angle_increment;
 }
 


### PR DESCRIPTION
## Summary
- correctly invert angle_min and angle_max in invertScan

## Testing
- `colcon build --packages-select ekf_slam` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68940e1aa95c832084355cd2051b331a