### PR TITLE
Normalize orientation angle to prevent pose jumps

### DIFF
--- a/include/utils/geometry_utils.hpp
+++ b/include/utils/geometry_utils.hpp
@@ -13,14 +13,15 @@ inline Eigen::Vector2d polarToCartesian(double range, double bearing) {
 }
 
 // Cartesian → Polar 변환 [range, bearing]
-inline Eigen::Vector2d cartesianToPolar(const Eigen::Vector2d& point) {
+inline Eigen::Vector2d cartesianToPolar(const Eigen::Vector2d &point) {
   double range = point.norm();
   double bearing = std::atan2(point.y(), point.x());
   return Eigen::Vector2d(range, bearing);
 }
 
 // World 좌표 → Robot 좌표계 변환
-inline Eigen::Vector2d worldToRobot(const Eigen::Vector2d& point, const Eigen::Vector3d& robot_pose) {
+inline Eigen::Vector2d worldToRobot(const Eigen::Vector2d &point,
+                                    const Eigen::Vector3d &robot_pose) {
   double dx = point.x() - robot_pose.x();
   double dy = point.y() - robot_pose.y();
   double theta = robot_pose.z();
@@ -32,13 +33,21 @@ inline Eigen::Vector2d worldToRobot(const Eigen::Vector2d& point, const Eigen::V
 }
 
 // Robot 좌표계 → World 좌표 변환
-inline Eigen::Vector2d robotToWorld(const Eigen::Vector2d& local_point, const Eigen::Vector3d& robot_pose) {
-  double x = robot_pose.x() + std::cos(robot_pose.z()) * local_point.x() - std::sin(robot_pose.z()) * local_point.y();
-  double y = robot_pose.y() + std::sin(robot_pose.z()) * local_point.x() + std::cos(robot_pose.z()) * local_point.y();
+inline Eigen::Vector2d robotToWorld(const Eigen::Vector2d &local_point,
+                                    const Eigen::Vector3d &robot_pose) {
+  double x = robot_pose.x() + std::cos(robot_pose.z()) * local_point.x() -
+             std::sin(robot_pose.z()) * local_point.y();
+  double y = robot_pose.y() + std::sin(robot_pose.z()) * local_point.x() +
+             std::cos(robot_pose.z()) * local_point.y();
   return Eigen::Vector2d(x, y);
 }
 
-}  // namespace utils
-}  // namespace ekf_slam
+// 각도 정규화 함수 [-pi, pi]
+inline double normalizeAngle(double angle) {
+  return std::atan2(std::sin(angle), std::cos(angle));
+}
 
-#endif  // EKF_SLAM_UTILS_GEOMETRY_UTILS_HPP_
+} // namespace utils
+} // namespace ekf_slam
+
+#endif // EKF_SLAM_UTILS_GEOMETRY_UTILS_HPP_

--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -1,5 +1,6 @@
 #include "core/slam_system.hpp"
 #include "association/data_association.hpp"
+#include "utils/geometry_utils.hpp"
 #include "utils/jacobian_utils.hpp"
 #include <Eigen/SparseCholesky>
 #include <cmath>
@@ -32,6 +33,7 @@ void EkfSlamSystem::predict(double v, double delta, double dt) {
   mu_(0) += dx;
   mu_(1) += dy;
   mu_(2) += dtheta;
+  mu_(2) = utils::normalizeAngle(mu_(2));
 
   // 자코비안 계산 (Gx)
   Eigen::Matrix3d Gx = ekf_slam::utils::computeMotionJacobian(v, theta, dt);
@@ -47,10 +49,10 @@ void EkfSlamSystem::predict(double v, double delta, double dt) {
   Fx.block(0, 0, 3, 3) = Eigen::Matrix3d::Identity();
 
   Eigen::MatrixXd G_bar = Eigen::MatrixXd::Identity(mu_.size(), mu_.size());
-  G_bar.block<3,3>(0,0) = Gx;
+  G_bar.block<3, 3>(0, 0) = Gx;
 
   sigma_ = G_bar * sigma_ * G_bar.transpose() + Fx.transpose() * R * Fx;
-  
+
   info_matrix_ = sigma_.inverse().sparseView();
   info_vector_ = info_matrix_ * mu_;
 }
@@ -62,7 +64,8 @@ void EkfSlamSystem::update(
     const std::vector<ekf_slam::laser::Observation> &observations) {
   for (const auto &obs : observations) {
     Eigen::Matrix2d Q = getMeasurementNoiseMatrix();
-    int id = data_associator_.associate(obs, mu_, sigma_, landmark_index_map_, Q);
+    int id =
+        data_associator_.associate(obs, mu_, sigma_, landmark_index_map_, Q);
     if (id == -1) {
       id = next_landmark_id_++;
       addLandmark(obs, id);
@@ -98,105 +101,109 @@ void EkfSlamSystem::update(
   sparsifyInformationMatrix(1e-6);
   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver(info_matrix_);
   mu_ = solver.solve(info_vector_);
+  mu_(2) = utils::normalizeAngle(mu_(2));
   sigma_ = solver.solve(
       Eigen::MatrixXd::Identity(info_matrix_.rows(), info_matrix_.cols()));
   info_vector_ = info_matrix_ * mu_;
 }
 
-  // -----------------------------
-  // 3. Landmark 추가
-  // -----------------------------
-  void EkfSlamSystem::addLandmark(const laser::Observation &obs,
-                                  int landmark_id) {
-    extendState(landmark_id, obs);
+// -----------------------------
+// 3. Landmark 추가
+// -----------------------------
+void EkfSlamSystem::addLandmark(const laser::Observation &obs,
+                                int landmark_id) {
+  extendState(landmark_id, obs);
+}
+
+// -----------------------------
+// 4. 상태 확장 (landmark 추가 시)
+// -----------------------------
+void EkfSlamSystem::extendState(int landmark_id,
+                                const laser::Observation &obs) {
+  double x = mu_(0);
+  double y = mu_(1);
+  double theta = mu_(2);
+
+  double lx = x + obs.range * std::cos(theta + obs.bearing);
+  double ly = y + obs.range * std::sin(theta + obs.bearing);
+
+  int old_size = mu_.size();
+
+  // 하이퍼파라미터 값 사용
+  double range_noise_var = meas_range_noise_ * meas_range_noise_;
+  double bearing_noise_var = meas_bearing_noise_ * meas_bearing_noise_;
+
+  // 공분산을 먼저 확장
+  expandCovarianceWithLandmark(old_size, obs.range, obs.bearing, theta,
+                               range_noise_var, bearing_noise_var);
+
+  // 상태 벡터 크기를 확장
+  mu_.conservativeResize(old_size + 2);
+  mu_(old_size) = lx;
+  mu_(old_size + 1) = ly;
+
+  landmark_index_map_[landmark_id] = old_size;
+
+  info_matrix_ = sigma_.inverse().sparseView();
+  info_vector_ = info_matrix_ * mu_;
+}
+// -----------------------------
+// 5. 기타 유틸
+// -----------------------------
+bool EkfSlamSystem::hasLandmark(int landmark_id) const {
+  return landmark_index_map_.count(landmark_id) > 0;
+}
+
+Eigen::Vector3d EkfSlamSystem::getCurrentPose() const {
+  Eigen::Vector3d pose = mu_.head<3>();
+  pose(2) = utils::normalizeAngle(pose(2));
+  return pose;
+}
+
+void EkfSlamSystem::expandCovarianceWithLandmark(int old_size, double range,
+                                                 double bearing, double theta,
+                                                 double range_noise_var,
+                                                 double bearing_noise_var) {
+  int new_size = old_size + 2;
+
+  // 기존 로봇 상태 공분산 추출 (x, y, theta assumed at 0~2)
+  Eigen::Matrix3d Sigma_xx = sigma_.block(0, 0, 3, 3);
+
+  double theta_phi = theta + bearing;
+  double sin_tp = std::sin(theta_phi);
+  double cos_tp = std::cos(theta_phi);
+
+  // Gx: 로봇 상태에서 랜드마크 위치로 가는 Jacobian
+  Eigen::Matrix<double, 2, 3> Gx;
+  Gx << 1, 0, -range * sin_tp, 0, 1, range * cos_tp;
+
+  // Gz: 관측에서 랜드마크 위치로 가는 Jacobian
+  Eigen::Matrix2d Gz;
+  Gz << cos_tp, -range * sin_tp, sin_tp, range * cos_tp;
+
+  // 관측 노이즈 공분산 R
+  Eigen::Matrix2d R;
+  R << range_noise_var, 0, 0, bearing_noise_var;
+
+  // 계산
+  Eigen::Matrix2d Sigma_r = Gz * R * Gz.transpose();
+  Eigen::Matrix<double, 2, 3> Sigma_xr = Gx * Sigma_xx;
+
+  // 공분산 행렬 확장
+  Eigen::MatrixXd new_sigma = Eigen::MatrixXd::Zero(new_size, new_size);
+  new_sigma.block(0, 0, old_size, old_size) = sigma_;
+  new_sigma.block(old_size, 0, 2, 3) = Sigma_xr;
+  new_sigma.block(0, old_size, 3, 2) = Sigma_xr.transpose();
+  new_sigma.block(old_size, old_size, 2, 2) = Sigma_r;
+
+  // 나머지 0 채움 (혹시 모르니 안전하게)
+  if (old_size > 3) {
+    new_sigma.block(old_size, 3, 2, old_size - 3).setZero();
+    new_sigma.block(3, old_size, old_size - 3, 2).setZero();
   }
 
-  // -----------------------------
-  // 4. 상태 확장 (landmark 추가 시)
-  // -----------------------------
-  void EkfSlamSystem::extendState(int landmark_id,
-                                  const laser::Observation &obs) {
-    double x = mu_(0);
-    double y = mu_(1);
-    double theta = mu_(2);
-
-    double lx = x + obs.range * std::cos(theta + obs.bearing);
-    double ly = y + obs.range * std::sin(theta + obs.bearing);
-
-    int old_size = mu_.size();
-
-    // 하이퍼파라미터 값 사용
-    double range_noise_var = meas_range_noise_ * meas_range_noise_;
-    double bearing_noise_var = meas_bearing_noise_ * meas_bearing_noise_;
-
-    // 공분산을 먼저 확장
-    expandCovarianceWithLandmark(old_size, obs.range, obs.bearing, theta,
-                                 range_noise_var, bearing_noise_var);
-
-    // 상태 벡터 크기를 확장
-    mu_.conservativeResize(old_size + 2);
-    mu_(old_size) = lx;
-    mu_(old_size + 1) = ly;
-
-    landmark_index_map_[landmark_id] = old_size;
-
-    info_matrix_ = sigma_.inverse().sparseView();
-    info_vector_ = info_matrix_ * mu_;
-  }
-  // -----------------------------
-  // 5. 기타 유틸
-  // -----------------------------
-  bool EkfSlamSystem::hasLandmark(int landmark_id) const {
-    return landmark_index_map_.count(landmark_id) > 0;
-  }
-
-  Eigen::Vector3d EkfSlamSystem::getCurrentPose() const {
-    return mu_.head<3>();
-  }
-
-void EkfSlamSystem::expandCovarianceWithLandmark(
-      int old_size, double range, double bearing, double theta,
-      double range_noise_var, double bearing_noise_var) {
-    int new_size = old_size + 2;
-
-    // 기존 로봇 상태 공분산 추출 (x, y, theta assumed at 0~2)
-    Eigen::Matrix3d Sigma_xx = sigma_.block(0, 0, 3, 3);
-
-    double theta_phi = theta + bearing;
-    double sin_tp = std::sin(theta_phi);
-    double cos_tp = std::cos(theta_phi);
-
-    // Gx: 로봇 상태에서 랜드마크 위치로 가는 Jacobian
-    Eigen::Matrix<double, 2, 3> Gx;
-    Gx << 1, 0, -range * sin_tp, 0, 1, range * cos_tp;
-
-    // Gz: 관측에서 랜드마크 위치로 가는 Jacobian
-    Eigen::Matrix2d Gz;
-    Gz << cos_tp, -range * sin_tp, sin_tp, range * cos_tp;
-
-    // 관측 노이즈 공분산 R
-    Eigen::Matrix2d R;
-    R << range_noise_var, 0, 0, bearing_noise_var;
-
-    // 계산
-    Eigen::Matrix2d Sigma_r = Gz * R * Gz.transpose();
-    Eigen::Matrix<double, 2, 3> Sigma_xr = Gx * Sigma_xx;
-
-    // 공분산 행렬 확장
-    Eigen::MatrixXd new_sigma = Eigen::MatrixXd::Zero(new_size, new_size);
-    new_sigma.block(0, 0, old_size, old_size) = sigma_;
-    new_sigma.block(old_size, 0, 2, 3) = Sigma_xr;
-    new_sigma.block(0, old_size, 3, 2) = Sigma_xr.transpose();
-    new_sigma.block(old_size, old_size, 2, 2) = Sigma_r;
-
-    // 나머지 0 채움 (혹시 모르니 안전하게)
-    if (old_size > 3) {
-      new_sigma.block(old_size, 3, 2, old_size - 3).setZero();
-      new_sigma.block(3, old_size, old_size - 3, 2).setZero();
-    }
-
-    sigma_ = new_sigma;
-  }
+  sigma_ = new_sigma;
+}
 
 Eigen::Matrix2d EkfSlamSystem::getMeasurementNoiseMatrix() const {
   Eigen::Matrix2d Q = Eigen::Matrix2d::Zero();


### PR DESCRIPTION
## Summary
- ensure orientation angles stay within [-pi, pi] with new utility
- apply angle normalization after prediction, update, and when retrieving pose

## Testing
- `colcon build --packages-select ekf_slam` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68941218dc388320a87653c04859e760