### PR TITLE
Add detailed logging to EKF update

### DIFF
--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -1,16 +1,18 @@
 #include "core/slam_system.hpp"
 #include "association/data_association.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "utils/geometry_utils.hpp"
 #include "utils/jacobian_utils.hpp"
 #include <Eigen/SparseCholesky>
 #include <cmath>
+#include <sstream>
 
 namespace ekf_slam {
-EkfSlamSystem::EkfSlamSystem(double noise_x, double noise_y,
-                             double noise_theta, double meas_range_noise,
-                             double meas_bearing_noise, double assoc_thresh)
-    : noise_x_(noise_x), noise_y_(noise_y),
-      noise_theta_(noise_theta), meas_range_noise_(meas_range_noise),
+EkfSlamSystem::EkfSlamSystem(double noise_x, double noise_y, double noise_theta,
+                             double meas_range_noise, double meas_bearing_noise,
+                             double assoc_thresh)
+    : noise_x_(noise_x), noise_y_(noise_y), noise_theta_(noise_theta),
+      meas_range_noise_(meas_range_noise),
       meas_bearing_noise_(meas_bearing_noise), data_associator_(assoc_thresh),
       next_landmark_id_(0) {
   mu_ = Eigen::VectorXd::Zero(3);
@@ -43,8 +45,7 @@ void EkfSlamSystem::predict(double v, double w, double dt) {
   mu_(2) = utils::normalizeAngle(theta + w * dt);
 
   // 자코비안 계산 (Gx)
-  Eigen::Matrix3d Gx =
-      ekf_slam::utils::computeMotionJacobian(v, theta, w, dt);
+  Eigen::Matrix3d Gx = ekf_slam::utils::computeMotionJacobian(v, theta, w, dt);
 
   // 제어 노이즈
   Eigen::Matrix3d R = Eigen::Matrix3d::Zero();
@@ -70,11 +71,14 @@ void EkfSlamSystem::predict(double v, double w, double dt) {
 // -----------------------------
 void EkfSlamSystem::update(
     const std::vector<ekf_slam::laser::Observation> &observations) {
+  auto logger = rclcpp::get_logger("EkfSlamSystem");
   for (const auto &obs : observations) {
     Eigen::Matrix2d Q = getMeasurementNoiseMatrix();
     int id =
         data_associator_.associate(obs, mu_, sigma_, landmark_index_map_, Q);
     if (id == -1) {
+      RCLCPP_DEBUG(logger, "No association found. Adding new landmark id %d",
+                   next_landmark_id_);
       id = next_landmark_id_++;
       addLandmark(obs, id);
       continue;
@@ -98,11 +102,37 @@ void EkfSlamSystem::update(
     innovation(1) = utils::normalizeAngle(innovation(1));
 
     Eigen::MatrixXd H = ekf_slam::utils::computeObservationJacobian(mu_, idx);
+    Eigen::Matrix2d S = H * sigma_ * H.transpose() + Q;
+    double mahalanobis = innovation.transpose() * S.inverse() * innovation;
+    RCLCPP_DEBUG(logger,
+                 "Association result -> id: %d, Mahalanobis distance: %.3f", id,
+                 mahalanobis);
+
+    double range_thresh = 3.0 * std::sqrt(Q(0, 0));
+    double bearing_thresh = 3.0 * std::sqrt(Q(1, 1));
+    if (std::abs(innovation(0)) > range_thresh ||
+        std::abs(innovation(1)) > bearing_thresh) {
+      RCLCPP_WARN(logger,
+                  "Innovation exceeds threshold: range %.3f, bearing %.3f",
+                  innovation(0), innovation(1));
+    }
+    RCLCPP_DEBUG(logger, "Innovation: [%.3f, %.3f]", innovation(0),
+                 innovation(1));
+
     Eigen::Matrix2d Q_inv = Q.inverse();
     Eigen::MatrixXd Ht_Qinv = H.transpose() * Q_inv;
 
     info_matrix_ += (Ht_Qinv * H).sparseView();
     info_vector_ += Ht_Qinv * (innovation + H * mu_);
+
+    Eigen::MatrixXd info_dense(info_matrix_);
+    std::stringstream ss_info;
+    ss_info << info_dense;
+    RCLCPP_DEBUG(logger, "info_matrix_:\n%s", ss_info.str().c_str());
+
+    std::stringstream ss_mu;
+    ss_mu << mu_.transpose();
+    RCLCPP_DEBUG(logger, "mu_: %s", ss_mu.str().c_str());
   }
 
   sparsifyInformationMatrix(1e-6);


### PR DESCRIPTION
## Summary
- log association results with Mahalanobis distance during EKF update
- record innovation, information matrix, and state vector for debugging
- warn when innovation exceeds threshold

## Testing
- `ctest` *(fails: Unable to find required file and missing linters)*

------
https://chatgpt.com/codex/tasks/task_e_689859f0eda4832093f68b94f34bffde