### PR TITLE
Log pose and covariance around predict and update

### DIFF
--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -1,29 +1,27 @@
 #ifndef EKF_SLAM_NODE_HPP_
 #define EKF_SLAM_NODE_HPP_
 
+#include <fstream>
 #include <memory>
 #include <string>
 
-
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
 
 #include "visualization/trajectory_visualizer.hpp"
 
-#include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 
-#include "preprocessing/laser_processor.hpp"
 #include "core/slam_system.hpp"
 #include "mapping/occupancy_mapper.hpp"
+#include "preprocessing/laser_processor.hpp"
 
-namespace ekf_slam
-{
+namespace ekf_slam {
 
-class SlamNode : public rclcpp::Node
-{
+class SlamNode : public rclcpp::Node {
 public:
   SlamNode();
   ~SlamNode();
@@ -32,14 +30,13 @@ public:
   void initialize();
 
 private:
-
   double noise_x_, noise_y_, noise_theta_;
   double meas_range_noise_, meas_bearing_noise_;
   double assoc_thresh_;
   int scan_downsample_;
   int map_width_, map_height_;
   double resolution_;
-  
+
   // LaserScan 수신 콜백
   void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
@@ -83,8 +80,11 @@ private:
   // TF 처리
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  // Logging 파일
+  std::ofstream log_file_;
 };
 
-}  // namespace ekf_slam
+} // namespace ekf_slam
 
-#endif  // EKF_SLAM_NODE_HPP_
+#endif // EKF_SLAM_NODE_HPP_

--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -6,16 +6,16 @@
 #include <unordered_map>
 #include <vector>
 
-#include "preprocessing/laser_processor.hpp"
 #include "association/data_association.hpp"
+#include "preprocessing/laser_processor.hpp"
 
 namespace ekf_slam {
 
 class EkfSlamSystem {
 public:
-  EkfSlamSystem(double noise_x, double noise_y,
-                double noise_theta, double meas_range_noise,
-                double meas_bearing_noise, double data_association_thresh);
+  EkfSlamSystem(double noise_x, double noise_y, double noise_theta,
+                double meas_range_noise, double meas_bearing_noise,
+                double data_association_thresh);
 
   // 예측: 제어입력 (선속도, 각속도), 시간 간격
   void predict(double v, double w, double dt);
@@ -31,6 +31,9 @@ public:
 
   // 현재 로봇 위치 (x, y, theta)
   Eigen::Vector3d getCurrentPose() const;
+
+  // 현재 공분산 행렬 반환
+  const Eigen::MatrixXd &getCovariance() const;
 
   // 랜드마크가 이미 있는지 확인
   bool hasLandmark(int landmark_id) const;

--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -6,11 +6,11 @@
 #include <cmath>
 
 namespace ekf_slam {
-EkfSlamSystem::EkfSlamSystem(double noise_x, double noise_y,
-                             double noise_theta, double meas_range_noise,
-                             double meas_bearing_noise, double assoc_thresh)
-    : noise_x_(noise_x), noise_y_(noise_y),
-      noise_theta_(noise_theta), meas_range_noise_(meas_range_noise),
+EkfSlamSystem::EkfSlamSystem(double noise_x, double noise_y, double noise_theta,
+                             double meas_range_noise, double meas_bearing_noise,
+                             double assoc_thresh)
+    : noise_x_(noise_x), noise_y_(noise_y), noise_theta_(noise_theta),
+      meas_range_noise_(meas_range_noise),
       meas_bearing_noise_(meas_bearing_noise), data_associator_(assoc_thresh),
       next_landmark_id_(0) {
   mu_ = Eigen::VectorXd::Zero(3);
@@ -43,8 +43,7 @@ void EkfSlamSystem::predict(double v, double w, double dt) {
   mu_(2) = utils::normalizeAngle(theta + w * dt);
 
   // 자코비안 계산 (Gx)
-  Eigen::Matrix3d Gx =
-      ekf_slam::utils::computeMotionJacobian(v, theta, w, dt);
+  Eigen::Matrix3d Gx = ekf_slam::utils::computeMotionJacobian(v, theta, w, dt);
 
   // 제어 노이즈
   Eigen::Matrix3d R = Eigen::Matrix3d::Zero();
@@ -166,6 +165,8 @@ Eigen::Vector3d EkfSlamSystem::getCurrentPose() const {
   pose(2) = utils::normalizeAngle(pose(2));
   return pose;
 }
+
+const Eigen::MatrixXd &EkfSlamSystem::getCovariance() const { return sigma_; }
 
 void EkfSlamSystem::expandCovarianceWithLandmark(int old_size, double range,
                                                  double bearing, double theta,


### PR DESCRIPTION
## Summary
- Add CSV logging for EKF pose and covariance before/after predict and update steps
- Expose covariance matrix from `EkfSlamSystem`
- Save logs to `log/ekf_log.csv` for offline analysis

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689859f1556c83209858cef9444ac5cb