### PR TITLE
Add CSV logging for EKF SLAM metrics

### DIFF
--- a/include/association/data_association.hpp
+++ b/include/association/data_association.hpp
@@ -17,12 +17,15 @@ public:
     DataAssociation(double mahalanobis_thresh);
 
     // 관측값에 대해 연관된 landmark_id 반환 (-1이면 신규)
+    // innovation_out: z_obs - z_pred, mahalanobis_out: Mahalanobis distance
     int associate(
         const laser::Observation& obs,
         const Eigen::VectorXd& mu,
         const Eigen::MatrixXd& sigma,
         const std::unordered_map<int, int>& landmark_index_map,
-        const Eigen::Matrix2d& Q); // 측정 노이즈 공분산
+        const Eigen::Matrix2d& Q,
+        Eigen::Vector2d& innovation_out,
+        double& mahalanobis_out); // 측정 노이즈 공분산
 
 private:
     double threshold_;  // 마할라노비스 거리 임계값

--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -5,6 +5,7 @@
 #include <Eigen/Sparse>
 #include <unordered_map>
 #include <vector>
+#include <fstream>
 
 #include "preprocessing/laser_processor.hpp"
 #include "association/data_association.hpp"
@@ -20,8 +21,9 @@ public:
   // 예측: 제어입력 (선속도, 각속도), 시간 간격
   void predict(double v, double w, double dt);
 
-  // 업데이트: 관측값 (range-bearing)
-  void update(const std::vector<laser::Observation> &observations);
+  // 업데이트: 관측값 (range-bearing)과 현재 시간(초)
+  void update(const std::vector<laser::Observation> &observations,
+              double timestamp);
 
   // 로봇 초기 pose 설정
   void setPose(double x, double y, double theta);
@@ -54,6 +56,9 @@ private:
 
   ekf_slam::DataAssociation data_associator_;
   int next_landmark_id_;
+
+  // 로그 파일 스트림
+  std::ofstream log_stream_;
 
   // 상태 확장 함수
   void extendState(int landmark_id, const laser::Observation &obs);

--- a/src/association/data_association.cpp
+++ b/src/association/data_association.cpp
@@ -13,9 +13,13 @@ int DataAssociation::associate(
     const laser::Observation &obs, const Eigen::VectorXd &mu,
     const Eigen::MatrixXd &sigma,
     const std::unordered_map<int, int> &landmark_index_map,
-    const Eigen::Matrix2d &Q) {
+    const Eigen::Matrix2d &Q,
+    Eigen::Vector2d &innovation_out,
+    double &mahalanobis_out) {
   double min_dist = threshold_;
   int matched_id = -1;
+  Eigen::Vector2d best_innovation = Eigen::Vector2d::Zero();
+  double best_dist = std::numeric_limits<double>::infinity();
 
   for (const auto &[landmark_id, idx] : landmark_index_map) {
     double lx = mu(idx);
@@ -53,9 +57,13 @@ int DataAssociation::associate(
     if (dist < min_dist) {
       min_dist = dist;
       matched_id = landmark_id;
+      best_innovation = innovation;
+      best_dist = dist;
     }
   }
 
+  innovation_out = best_innovation;
+  mahalanobis_out = best_dist;
   return matched_id;
 }
 

--- a/src/core/slam_node.cpp
+++ b/src/core/slam_node.cpp
@@ -142,7 +142,9 @@ void SlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
   auto observations = laser_processor_->process(*msg);
 
   // EKF SLAM 업데이트
-  ekf_->update(observations);
+  double timestamp = msg->header.stamp.sec +
+                     msg->header.stamp.nanosec * 1e-9;
+  ekf_->update(observations, timestamp);
 
   // 현재 추정된 로봇 pose 출력
   auto pose = ekf_->getCurrentPose();


### PR DESCRIPTION
## Summary
- log pose, innovation, and Mahalanobis distance to `slam_log.csv`
- expose innovation and distance in data association for logging
- allow slam system update to accept timestamp and write CSV rows

## Testing
- `colcon build` *(fails: Could not find package configuration file provided by "ament_cmake" )*


------
https://chatgpt.com/codex/tasks/task_e_689859f1c2fc83208bdcb48201e26ac9