### PR TITLE
Fix compilation issues in DataAssociation and EKF update

### DIFF
--- a/src/association/data_association.cpp
+++ b/src/association/data_association.cpp
@@ -14,13 +14,8 @@ int DataAssociation::associate(
     const laser::Observation &obs, const Eigen::VectorXd &mu,
     const Eigen::MatrixXd &sigma,
     const std::unordered_map<int, int> &landmark_index_map,
-
-    const Eigen::Matrix2d &Q,
-    Eigen::Vector2d &innovation_out,
+    const Eigen::Matrix2d &Q, Eigen::Vector2d &innovation_out,
     double &mahalanobis_out) {
-  double min_dist = threshold_;
-
-    const Eigen::Matrix2d &Q) {
   double min_dist = std::numeric_limits<double>::infinity();
 
   int matched_id = -1;

--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -76,14 +76,13 @@ void EkfSlamSystem::predict(double v, double w, double dt) {
 // -----------------------------
 // 2. Update
 // -----------------------------
-void EkfSlamSystem::update(
-    const std::vector<ekf_slam::laser::Observation> &observations,
-    double timestamp) {
-  std::vector<std::pair<Eigen::Vector2d, double>> log_entries;
-  log_entries.reserve(observations.size());
+  void EkfSlamSystem::update(
+      const std::vector<ekf_slam::laser::Observation> &observations,
+      double timestamp) {
+    std::vector<std::pair<Eigen::Vector2d, double>> log_entries;
+    log_entries.reserve(observations.size());
 
-    const std::vector<ekf_slam::laser::Observation> &observations) {
-  auto logger = rclcpp::get_logger("EkfSlamSystem");
+    auto logger = rclcpp::get_logger("EkfSlamSystem");
 
   for (const auto &obs : observations) {
     Eigen::Matrix2d Q = getMeasurementNoiseMatrix();
@@ -141,7 +140,6 @@ void EkfSlamSystem::update(
     info_vector_ += Ht_Qinv * (innovation_update + H * mu_);
 
     log_entries.emplace_back(innovation, mahal_dist);
-    info_vector_ += Ht_Qinv * (innovation + H * mu_);
 
     Eigen::MatrixXd info_dense(info_matrix_);
     std::stringstream ss_info;


### PR DESCRIPTION
## Summary
- clean up DataAssociation::associate implementation to remove stray signature and properly initialize variables
- remove duplicated update signature and redundant information vector addition in EKF update

## Testing
- `cmake -S . -B build/ekf_slam` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689862530eb48320b49889dcabb5390f