### PR TITLE
Fix timestamp conversion and unit test parameters

### DIFF
--- a/src/core/slam_node.cpp
+++ b/src/core/slam_node.cpp
@@ -174,7 +174,7 @@ void SlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg) {
   // LaserScan → 관측값 변환
   auto observations = laser_processor_->process(*msg);
 
-  double time_sec = msg->header.stamp.seconds();
+  double time_sec = rclcpp::Time(msg->header.stamp).seconds();
 
   // Update 이전 상태 기록
   auto pre_pose = ekf_->getCurrentPose();

--- a/test/unit_tests/test_ekf_core.cpp
+++ b/test/unit_tests/test_ekf_core.cpp
@@ -34,7 +34,7 @@ TEST(EkfSlamSystemTest, LandmarkUpdate)
 
   std::vector<ekf_slam::laser::Observation> observations = { obs };
 
-  slam.update(observations);
+  slam.update(observations, 0.0);
 
   // 랜드마크가 추가되었는지 확인
   Eigen::Vector3d pose = slam.getCurrentPose();


### PR DESCRIPTION
## Summary
- fix scan callback timestamp conversion using rclcpp::Time
- update unit test to provide timestamp to update call

## Testing
- `cmake ..` *(failed: Could not find package configuration file provided by "ament_cmake"; add ament_cmake to CMAKE_PREFIX_PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689864d67ce8832083a5ef7dcaeb5026