### PR TITLE
Ensure Matplotlib uses NumPy arrays in log analyzer

### DIFF
--- a/scripts/analyze_slam_log.py
+++ b/scripts/analyze_slam_log.py
@@ -28,7 +28,7 @@ def plot_trajectory(df: pd.DataFrame, out_dir: Path) -> None:
     if {"x", "y"} <= set(df.columns):
         out_dir.mkdir(parents=True, exist_ok=True)
         plt.figure()
-        plt.plot(df["x"], df["y"], label="trajectory")
+        plt.plot(df["x"].to_numpy(), df["y"].to_numpy(), label="trajectory")
         plt.xlabel("x")
         plt.ylabel("y")
         plt.title("SLAM Trajectory")
@@ -47,7 +47,7 @@ def plot_time_series(df: pd.DataFrame, columns: Iterable[str], out_dir: Path) ->
         if col not in df.columns:
             continue
         plt.figure()
-        plt.plot(df.index, df[col])
+        plt.plot(df.index.to_numpy(), df[col].to_numpy())
         plt.xlabel("index")
         plt.ylabel(col)
         plt.title(f"{col} over time")


### PR DESCRIPTION
## Summary
- Convert DataFrame columns to NumPy arrays before plotting trajectories and time series to avoid Series indexing issues.

## Testing
- `python scripts/analyze_slam_log.py slam_log.csv --out plots`


------
https://chatgpt.com/codex/tasks/task_e_6898701d21108320b550fd5c1bb5c874