### PR TITLE
Revert to EKF Kalman gain and remove debug

### DIFF
--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -2,10 +2,8 @@
 #define EKF_SLAM_SYSTEM_HPP_
 
 #include <Eigen/Dense>
-#include <Eigen/Sparse>
 #include <unordered_map>
 #include <vector>
-#include <fstream>
 
 #include "association/data_association.hpp"
 #include "preprocessing/laser_processor.hpp"
@@ -47,10 +45,6 @@ private:
   // 공분산 행렬
   Eigen::MatrixXd sigma_;
 
-  // Sparse Extended Information Filter representation
-  Eigen::SparseMatrix<double> info_matrix_;
-  Eigen::VectorXd info_vector_;
-
   double noise_x_, noise_y_, noise_theta_; // control noise
   double meas_range_noise_, meas_bearing_noise_;
 
@@ -59,9 +53,6 @@ private:
 
   ekf_slam::DataAssociation data_associator_;
   int next_landmark_id_;
-
-  // 로그 파일 스트림
-  std::ofstream log_stream_;
 
   // 상태 확장 함수
   void extendState(int landmark_id, const laser::Observation &obs);
@@ -72,8 +63,6 @@ private:
                                     double bearing_noise_var);
 
   Eigen::Matrix2d getMeasurementNoiseMatrix() const;
-
-  void sparsifyInformationMatrix(double threshold);
 };
 
 } // namespace ekf_slam

--- a/src/core/slam_node.cpp
+++ b/src/core/slam_node.cpp
@@ -200,8 +200,6 @@ void SlamNode::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg) {
             << "," << post_cov(1, 2) << "," << post_cov(2, 0) << ","
             << post_cov(2, 1) << "," << post_cov(2, 2) << "\n";
   log_file_.flush();
-  RCLCPP_INFO(this->get_logger(), "Pose: x=%.2f, y=%.2f, θ=%.2f", pose(0),
-              pose(1), pose(2));
 
   // occupancy mapping을 위한 데이터 전송
   occupancy_mapper_->addScanData(pose, *msg);
@@ -217,11 +215,6 @@ void SlamNode::publishMap() {
     auto occupancy_grid = occupancy_mapper_->getOccupancyGrid();
     map_pub_->publish(occupancy_grid);
 
-    // 디버그 정보
-    static int map_count = 0;
-    if (++map_count % 10 == 0) {
-      RCLCPP_INFO(this->get_logger(), "Published occupancy map #%d", map_count);
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- revert SLAM core to standard EKF using Kalman gain
- strip debugging logs from SLAM core and node

## Testing
- `colcon build --packages-select ekf_slam` *(fails: Could not find a package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_6898755bfb348320b3a42cbd84383b7e