### PR TITLE
Switch to bicycle motion model

### DIFF
--- a/config/slam_params.yaml
+++ b/config/slam_params.yaml
@@ -16,3 +16,4 @@ ekf_slam:
       width: 1500
       height: 1500
       resolution: 0.05
+    wheel_base: 0.33

--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -40,6 +40,7 @@ private:
   int scan_downsample_;
   int map_width_, map_height_;
   double resolution_;
+  double wheel_base_;
   
   // LaserScan 수신 콜백
   void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);

--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -16,10 +16,10 @@ public:
   EkfSlamSystem(double noise_x, double noise_y,
                 double noise_theta, double meas_range_noise,
                 double meas_bearing_noise, double data_association_thresh,
-                double data_association_ratio);
+                double data_association_ratio, double wheel_base);
 
-  // 예측: 제어입력 (선속도, 각속도), 시간 간격
-  void predict(double v, double w, double dt);
+  // 예측: 제어입력 (선속도, 조향각), 시간 간격
+  void predict(double v, double steering, double dt);
 
   // 업데이트: 관측값 (range-bearing)
   void update(const std::vector<laser::Observation> &observations);
@@ -46,6 +46,7 @@ private:
 
   double noise_x_, noise_y_, noise_theta_; // control noise
   double meas_range_noise_, meas_bearing_noise_;
+  double wheel_base_;
 
   // 랜드마크 ID → mu_ 인덱스 매핑
   std::unordered_map<int, int> landmark_index_map_;

--- a/test/unit_tests/test_ekf_core.cpp
+++ b/test/unit_tests/test_ekf_core.cpp
@@ -3,7 +3,7 @@
 
 TEST(EkfSlamSystemTest, Initialization)
 {
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
   Eigen::Vector3d pose = slam.getCurrentPose();
   EXPECT_NEAR(pose(0), 0.0, 1e-6);
   EXPECT_NEAR(pose(1), 0.0, 1e-6);
@@ -12,9 +12,9 @@ TEST(EkfSlamSystemTest, Initialization)
 
 TEST(EkfSlamSystemTest, PredictMotion)
 {
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
 
-  // v = 1.0 m/s, w = 0.0 rad/s, dt = 1.0 s → 직선 전진
+  // v = 1.0 m/s, steering = 0.0 rad, dt = 1.0 s → 직선 전진
   slam.predict(1.0, 0.0, 1.0);
 
   Eigen::Vector3d pose = slam.getCurrentPose();
@@ -25,7 +25,7 @@ TEST(EkfSlamSystemTest, PredictMotion)
 
 TEST(EkfSlamSystemTest, LandmarkUpdate)
 {
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
 
   // 관측된 landmark 하나 추가
   ekf_slam::laser::Observation obs;


### PR DESCRIPTION
## Summary
- replace unicycle kinematics with bicycle model using steering angle
- expose wheel_base parameter and forward it to EKF
- update unit tests for new predict interface

## Testing
- `colcon build --packages-select ekf_slam` *(failed: Could not find a package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_6898a6c1c1a88320803853f69f615848