### PR TITLE
Refactor prediction to use yaw rate

### DIFF
--- a/config/slam_params.yaml
+++ b/config/slam_params.yaml
@@ -16,4 +16,3 @@ ekf_slam:
       width: 1500
       height: 1500
       resolution: 0.05
-    wheel_base: 0.33

--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -4,26 +4,23 @@
 #include <memory>
 #include <string>
 
-
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/laser_scan.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
 
 #include "visualization/trajectory_visualizer.hpp"
 
-#include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 
-#include "preprocessing/laser_processor.hpp"
 #include "core/slam_system.hpp"
 #include "mapping/occupancy_mapper.hpp"
+#include "preprocessing/laser_processor.hpp"
 
-namespace ekf_slam
-{
+namespace ekf_slam {
 
-class SlamNode : public rclcpp::Node
-{
+class SlamNode : public rclcpp::Node {
 public:
   SlamNode();
   ~SlamNode();
@@ -32,7 +29,6 @@ public:
   void initialize();
 
 private:
-
   double noise_x_, noise_y_, noise_theta_;
   double meas_range_noise_, meas_bearing_noise_;
   double assoc_thresh_;
@@ -40,8 +36,7 @@ private:
   int scan_downsample_;
   int map_width_, map_height_;
   double resolution_;
-  double wheel_base_;
-  
+
   // LaserScan 수신 콜백
   void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 
@@ -81,6 +76,6 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
-}  // namespace ekf_slam
+} // namespace ekf_slam
 
-#endif  // EKF_SLAM_NODE_HPP_
+#endif // EKF_SLAM_NODE_HPP_

--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -6,20 +6,19 @@
 #include <unordered_map>
 #include <vector>
 
-#include "preprocessing/laser_processor.hpp"
 #include "association/data_association.hpp"
+#include "preprocessing/laser_processor.hpp"
 
 namespace ekf_slam {
 
 class EkfSlamSystem {
 public:
-  EkfSlamSystem(double noise_x, double noise_y,
-                double noise_theta, double meas_range_noise,
-                double meas_bearing_noise, double data_association_thresh,
-                double data_association_ratio, double wheel_base);
+  EkfSlamSystem(double noise_x, double noise_y, double noise_theta,
+                double meas_range_noise, double meas_bearing_noise,
+                double data_association_thresh, double data_association_ratio);
 
-  // 예측: 제어입력 (선속도, 조향각), 시간 간격
-  void predict(double v, double steering, double dt);
+  // 예측: 제어입력 (선속도, 요속도), 시간 간격
+  void predict(double v, double yaw_rate, double dt);
 
   // 업데이트: 관측값 (range-bearing)
   void update(const std::vector<laser::Observation> &observations);
@@ -46,7 +45,6 @@ private:
 
   double noise_x_, noise_y_, noise_theta_; // control noise
   double meas_range_noise_, meas_bearing_noise_;
-  double wheel_base_;
 
   // 랜드마크 ID → mu_ 인덱스 매핑
   std::unordered_map<int, int> landmark_index_map_;

--- a/test/unit_tests/test_ekf_core.cpp
+++ b/test/unit_tests/test_ekf_core.cpp
@@ -1,20 +1,18 @@
-#include <gtest/gtest.h>
 #include "../../include/core/slam_system.hpp"
+#include <gtest/gtest.h>
 
-TEST(EkfSlamSystemTest, Initialization)
-{
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
+TEST(EkfSlamSystemTest, Initialization) {
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
   Eigen::Vector3d pose = slam.getCurrentPose();
   EXPECT_NEAR(pose(0), 0.0, 1e-6);
   EXPECT_NEAR(pose(1), 0.0, 1e-6);
   EXPECT_NEAR(pose(2), 0.0, 1e-6);
 }
 
-TEST(EkfSlamSystemTest, PredictMotion)
-{
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
+TEST(EkfSlamSystemTest, PredictMotion) {
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
 
-  // v = 1.0 m/s, steering = 0.0 rad, dt = 1.0 s → 직선 전진
+  // v = 1.0 m/s, yaw_rate = 0.0 rad/s, dt = 1.0 s → 직선 전진
   slam.predict(1.0, 0.0, 1.0);
 
   Eigen::Vector3d pose = slam.getCurrentPose();
@@ -23,16 +21,15 @@ TEST(EkfSlamSystemTest, PredictMotion)
   EXPECT_NEAR(pose(2), 0.0, 1e-3); // heading 변화 없음
 }
 
-TEST(EkfSlamSystemTest, LandmarkUpdate)
-{
-  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8, 0.5);
+TEST(EkfSlamSystemTest, LandmarkUpdate) {
+  ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
 
   // 관측된 landmark 하나 추가
   ekf_slam::laser::Observation obs;
   obs.range = 1.0;
   obs.bearing = 0.0;
 
-  std::vector<ekf_slam::laser::Observation> observations = { obs };
+  std::vector<ekf_slam::laser::Observation> observations = {obs};
 
   slam.update(observations);
 
@@ -43,5 +40,5 @@ TEST(EkfSlamSystemTest, LandmarkUpdate)
   EXPECT_NEAR(pose(2), 0.0, 1e-6);
 
   // landmark가 존재해야 한다
-  EXPECT_TRUE(slam.hasLandmark(0));  // 첫 번째 landmark ID는 0일 가능성 높음
+  EXPECT_TRUE(slam.hasLandmark(0)); // 첫 번째 landmark ID는 0일 가능성 높음
 }


### PR DESCRIPTION
## Summary
- Update EKF prediction to accept yaw rate directly instead of steering angle
- Remove wheel base parameter and associated conversion logic
- Adjust node, config, and tests for new interface

## Testing
- `colcon build --packages-select ekf_slam` *(fails: ament_cmake package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68999ddee5fc8320930d31b61f752a4a