### PR TITLE
Use odom orientation yaw in EKF predict

### DIFF
--- a/include/core/slam_system.hpp
+++ b/include/core/slam_system.hpp
@@ -17,8 +17,8 @@ public:
                 double meas_range_noise, double meas_bearing_noise,
                 double data_association_thresh, double data_association_ratio);
 
-  // 예측: 제어입력 (선속도, 요속도), 시간 간격
-  void predict(double v, double yaw_rate, double dt);
+  // 예측: 제어입력 (선속도, 절대 요각), 시간 간격
+  void predict(double v, double yaw, double dt);
 
   // 업데이트: 관측값 (range-bearing)
   void update(const std::vector<laser::Observation> &observations);

--- a/test/unit_tests/test_ekf_core.cpp
+++ b/test/unit_tests/test_ekf_core.cpp
@@ -12,7 +12,7 @@ TEST(EkfSlamSystemTest, Initialization) {
 TEST(EkfSlamSystemTest, PredictMotion) {
   ekf_slam::EkfSlamSystem slam(0.01, 0.01, 0.01, 0.5, 0.1, 2.0, 0.8);
 
-  // v = 1.0 m/s, yaw_rate = 0.0 rad/s, dt = 1.0 s → 직선 전진
+  // v = 1.0 m/s, yaw = 0.0 rad, dt = 1.0 s → 직선 전진
   slam.predict(1.0, 0.0, 1.0);
 
   Eigen::Vector3d pose = slam.getCurrentPose();


### PR DESCRIPTION
## Summary
- extract yaw from odometry pose orientation and use it in predict
- update EKF predict to accept absolute yaw instead of yaw rate
- adjust unit test for new predict signature

## Testing
- `colcon build --packages-select ekf_slam` *(fails: Could not find a package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_6899cae104c08320b00099b96282a730