### PR TITLE
Fix missing observation Jacobian include

### DIFF
--- a/src/core/slam_system.cpp
+++ b/src/core/slam_system.cpp
@@ -1,6 +1,7 @@
 #include "core/slam_system.hpp"
 #include "association/data_association.hpp"
 #include "utils/geometry_utils.hpp"
+#include "utils/jacobian_utils.hpp"
 #include <Eigen/SparseCholesky>
 #include <cmath>
 


### PR DESCRIPTION
## Summary
- include `jacobian_utils.hpp` so the EKF update step finds `computeObservationJacobian`

## Testing
- `cmake -S . -B build` *(fails: could not find ament_cmake)*


------
https://chatgpt.com/codex/tasks/task_e_6899d67c50948320a26d2883120bc0e6