### PR TITLE
Add missing tf2 utils include for yaw extraction

### DIFF
--- a/src/core/slam_node.cpp
+++ b/src/core/slam_node.cpp
@@ -2,6 +2,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/utils.h"
 
 #include <cmath>
 #include <memory>


### PR DESCRIPTION
## Summary
- include `tf2/utils.h` so `tf2::getYaw` is available in `SlamNode`

## Testing
- `colcon build --packages-select ekf_slam` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package python3-colcon-common-extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6899d84d1aa0832086f4a701e521ca3f