### PR TITLE
Add map saving service producing PGM and YAML files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
@@ -41,6 +42,7 @@ ament_target_dependencies(${PROJECT_NAME}_lib
   tf2
   tf2_ros
   tf2_geometry_msgs
+  std_srvs
   Eigen3
 )
 
@@ -59,6 +61,7 @@ ament_target_dependencies(slam_node
   tf2
   tf2_ros
   tf2_geometry_msgs
+  std_srvs
   Eigen3
 )
 target_link_libraries(slam_node ${PROJECT_NAME}_lib)

--- a/include/core/slam_node.hpp
+++ b/include/core/slam_node.hpp
@@ -8,6 +8,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 #include "visualization/trajectory_visualizer.hpp"
 
@@ -36,6 +37,7 @@ private:
   int scan_downsample_;
   int map_width_, map_height_;
   double resolution_;
+  std::string map_save_prefix_;
 
   // LaserScan 수신 콜백
   void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
@@ -45,6 +47,8 @@ private:
 
   // Occupancy map publish 함수
   void publishMap();
+  void saveMapServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+                              std::shared_ptr<std_srvs::srv::Trigger::Response>);
 
   // EKF SLAM 알고리즘 객체
   std::shared_ptr<ekf_slam::EkfSlamSystem> ekf_;
@@ -61,6 +65,7 @@ private:
 
   // ROS2 Publisher for map
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr save_map_srv_;
 
   // Trajectory visualizer
   std::shared_ptr<TrajectoryVisualizer> trajectory_visualizer_;

--- a/include/mapping/occupancy_mapper.hpp
+++ b/include/mapping/occupancy_mapper.hpp
@@ -7,6 +7,7 @@
 #include <queue>
 #include <atomic>
 #include <condition_variable>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
@@ -38,6 +39,7 @@ public:
     
     // 맵 데이터 접근
     nav_msgs::msg::OccupancyGrid getOccupancyGrid() const;
+    bool saveMap(const std::string& file_prefix) const;
     bool isInitialized() const { return initialized_; }
     
     // 설정

--- a/package.xml
+++ b/package.xml
@@ -22,9 +22,10 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>tf2</depend>ㅌㄴ
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>std_srvs</depend>
   
   <!-- Math and computation -->
   <depend>eigen3_cmake_module</depend>


### PR DESCRIPTION
## Summary
- allow OccupancyMapper to export maps to PGM and YAML
- expose a `save_map` Trigger service on SlamNode to save the current map
- add std_srvs dependency and build wiring

## Testing
- `python3 -m colcon build --packages-select ekf_slam` *(fails: Could not find a package configuration file provided by "ament_cmake" )*


------
https://chatgpt.com/codex/tasks/task_e_689c31a073bc832090a1790bbe1db581