### PR TITLE
Ensure directory exists before saving map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(ekf_slam)
 
+# Use C++17 for std::filesystem and other modern features
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Compiler settings
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/src/mapping/occupancy_mapper.cpp
+++ b/src/mapping/occupancy_mapper.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <fstream>
 #include <string>
+#include <filesystem>
 
 namespace ekf_slam {
 
@@ -258,6 +259,19 @@ nav_msgs::msg::OccupancyGrid OccupancyMapper::getOccupancyGrid() const {
 
 bool OccupancyMapper::saveMap(const std::string& file_prefix) const {
     auto grid = getOccupancyGrid();
+
+    // Ensure the output directory exists
+    namespace fs = std::filesystem;
+    fs::path prefix_path(file_prefix);
+    if (prefix_path.has_parent_path()) {
+        std::error_code ec;
+        fs::create_directories(prefix_path.parent_path(), ec);
+        if (ec) {
+            RCLCPP_ERROR(node_->get_logger(), "Failed to create directory %s: %s",
+                         prefix_path.parent_path().string().c_str(), ec.message().c_str());
+            return false;
+        }
+    }
 
     std::string pgm_file = file_prefix + ".pgm";
     std::string yaml_file = file_prefix + ".yaml";


### PR DESCRIPTION
## Summary
- create output directory before saving occupancy grid
- enable C++17 to use std::filesystem

## Testing
- `colcon build --packages-select ekf_slam` *(fails: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c41bd3bcc83209904d90dea6cd417