### PR TITLE
Add distance-based weighting for occupancy updates

### DIFF
--- a/config/slam_params.yaml
+++ b/config/slam_params.yaml
@@ -16,3 +16,8 @@ ekf_slam:
       width: 1500
       height: 1500
       resolution: 0.05
+      log_odds:
+        occ_prob: 0.7
+        free_prob: 0.3
+        weight_min: 0.1
+        weight_max: 1.0

--- a/include/mapping/occupancy_mapper.hpp
+++ b/include/mapping/occupancy_mapper.hpp
@@ -43,7 +43,8 @@ public:
     bool isInitialized() const { return initialized_; }
     
     // 설정
-    void setLogOddsParameters(double occ_prob = 0.7, double free_prob = 0.3);
+    void setLogOddsParameters(double occ_prob = 0.7, double free_prob = 0.3,
+                              double min_weight = 0.1, double max_weight = 1.0);
     void setMaxRange(double max_range) { max_range_ = max_range; }
 
 private:
@@ -58,6 +59,7 @@ private:
     // Log-odds 파라미터
     double log_odds_occ_, log_odds_free_;
     double log_odds_max_, log_odds_min_;
+    double min_weight_, max_weight_;
     
     // 맵 데이터
     std::vector<std::vector<double>> log_odds_map_;


### PR DESCRIPTION
## Summary
- Scale log-odds updates by distance along each laser ray so distant cells change less
- Expose minimum/maximum decay weights as configurable parameters
- Allow log-odds and weight parameters to be set via YAML

## Testing
- `colcon build --packages-select ekf_slam --event-handlers console_direct+` *(fails: Could not find a package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_689c4b07d2308320bcdcb505b2d8e035