### PR TITLE
Add synchronized data logging and polar grid conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(message_filters REQUIRED)
+find_package(trajectory_msgs REQUIRED)
 
 
 # Create library
@@ -70,6 +72,32 @@ ament_target_dependencies(slam_node
 )
 target_link_libraries(slam_node ${PROJECT_NAME}_lib)
 
+add_executable(global_to_polar_node
+  src/tools/global_to_polar_node.cpp
+)
+ament_target_dependencies(global_to_polar_node
+  rclcpp
+  sensor_msgs
+  nav_msgs
+  trajectory_msgs
+  tf2
+  tf2_ros
+)
+
+add_executable(data_logger_node
+  src/tools/data_logger_node.cpp
+)
+ament_target_dependencies(data_logger_node
+  rclcpp
+  sensor_msgs
+  nav_msgs
+  trajectory_msgs
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+  message_filters
+)
+
 target_include_directories(${PROJECT_NAME}_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
@@ -78,6 +106,8 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC
 # Install executables
 install(TARGETS
   slam_node
+  global_to_polar_node
+  data_logger_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/launch/polar_logging.launch.py
+++ b/launch/polar_logging.launch.py
@@ -1,0 +1,29 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    params = {
+        'horizon_sec': 1.6,
+        'dt': 0.1,
+        'forward_only': False,
+        'normalize': False,
+        'downsample': 1,
+        'output_csv_file': 'data_log.csv'
+    }
+
+    return LaunchDescription([
+        Node(
+            package='ekf_slam',
+            executable='global_to_polar_node',
+            name='global_to_polar',
+            remappings=[('/pf/pose/odom', '/pf/pose/odom'),
+                        ('/planned_path_with_velocity', '/planned_path_with_velocity')]
+        ),
+        Node(
+            package='ekf_slam',
+            executable='data_logger_node',
+            name='data_logger',
+            remappings=[('/planned_path_with_velocity', '/planned_path_with_velocity')],
+            parameters=[params]
+        )
+    ])

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>message_filters</depend>
+  <depend>trajectory_msgs</depend>
   
   <!-- Math and computation -->
   <depend>eigen3_cmake_module</depend>

--- a/src/tools/data_logger_node.cpp
+++ b/src/tools/data_logger_node.cpp
@@ -1,0 +1,209 @@
+#include <fstream>
+#include <iomanip>
+#include <vector>
+#include <algorithm>
+#include <limits>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "trajectory_msgs/msg/multi_dof_joint_trajectory.hpp"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.h"
+#include "tf2/LinearMath/Transform.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "message_filters/subscriber.h"
+#include "message_filters/synchronizer.h"
+#include "message_filters/sync_policies/approximate_time.h"
+
+class DataLoggerNode : public rclcpp::Node
+{
+public:
+  DataLoggerNode()
+  : Node("data_logger_node"), counter_(0)
+  {
+    horizon_sec_ = declare_parameter<double>("horizon_sec", 1.6);
+    dt_ = declare_parameter<double>("dt", 0.1);
+    forward_only_ = declare_parameter<bool>("forward_only", false);
+    normalize_ = declare_parameter<bool>("normalize", false);
+    downsample_ = declare_parameter<int>("downsample", 1);
+    std::string file = declare_parameter<std::string>("output_csv_file", "data_log.csv");
+
+    file_.open(file, std::ios::out | std::ios::app);
+    if (!file_.is_open()) {
+      RCLCPP_ERROR(get_logger(), "Failed to open %s", file.c_str());
+    }
+
+    tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    scan_sub_.subscribe(this, "/scan");
+    grid_sub_.subscribe(this, "/polar_grid");
+    path_sub_.subscribe(this, "/planned_path_with_velocity");
+
+    sync_ = std::make_shared<Synchronizer>(Synchronizer(SyncPolicy(10), scan_sub_, grid_sub_, path_sub_));
+    sync_->registerCallback(&DataLoggerNode::dataCallback, this);
+  }
+
+private:
+  using PathMsg = trajectory_msgs::msg::MultiDOFJointTrajectory;
+  using SyncPolicy = message_filters::sync_policies::ApproximateTime<
+    sensor_msgs::msg::LaserScan,
+    sensor_msgs::msg::LaserScan,
+    PathMsg>;
+  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+
+  void dataCallback(
+    const sensor_msgs::msg::LaserScan::ConstSharedPtr scan,
+    const sensor_msgs::msg::LaserScan::ConstSharedPtr grid,
+    const PathMsg::ConstSharedPtr path)
+  {
+    if (counter_++ % std::max(1, downsample_) != 0) {
+      return;
+    }
+
+    if (scan->ranges.size() != 1080 || grid->ranges.size() != 1080) {
+      RCLCPP_WARN(get_logger(), "Scan or grid size mismatch");
+      return;
+    }
+
+    std::vector<double> scan_vals(1080);
+    for (size_t i = 0; i < 1080; ++i) {
+      double r = scan->ranges[i];
+      if (!std::isfinite(r) || r > scan->range_max || r < scan->range_min) {
+        r = scan->range_max;
+      }
+      if (normalize_) {
+        r /= scan->range_max;
+      }
+      scan_vals[i] = r;
+    }
+
+    std::vector<double> grid_vals(1080);
+    for (size_t i = 0; i < 1080; ++i) {
+      double g = grid->ranges[i];
+      if (!std::isfinite(g)) {
+        g = 0.0;
+      }
+      grid_vals[i] = g;
+    }
+
+    std::vector<double> times;
+    std::vector<double> xs;
+    std::vector<double> ys;
+
+    geometry_msgs::msg::TransformStamped tf;
+    try {
+      tf = tf_buffer_->lookupTransform("base_link", "map", scan->header.stamp, rclcpp::Duration::from_seconds(0.1));
+    } catch (const tf2::TransformException & e) {
+      RCLCPP_WARN(get_logger(), "TF lookup failed: %s", e.what());
+      return;
+    }
+    tf2::Transform tf_map_base;
+    tf2::fromMsg(tf.transform, tf_map_base);
+
+    for (const auto & pt : path->points) {
+      if (pt.transforms.empty()) {
+        continue;
+      }
+      const auto & tr = pt.transforms[0].translation;
+      tf2::Vector3 p_map(tr.x, tr.y, 0.0);
+      tf2::Vector3 p_base = tf_map_base * p_map;
+      double t = rclcpp::Time(pt.time_from_start).seconds();
+      times.push_back(t);
+      xs.push_back(p_base.x());
+      ys.push_back(p_base.y());
+    }
+
+    if (times.empty()) {
+      RCLCPP_WARN(get_logger(), "Empty path points");
+      return;
+    }
+
+    int label_count = static_cast<int>(horizon_sec_ / dt_);
+    std::vector<double> label_x(label_count, 0.0);
+    std::vector<double> label_y(label_count, 0.0);
+    double last_x = 0.0, last_y = 0.0;
+
+    for (int i = 0; i < label_count; ++i) {
+      double target_t = i * dt_;
+      double x = xs.back();
+      double y = ys.back();
+
+      if (target_t <= times.front()) {
+        x = xs.front();
+        y = ys.front();
+      } else if (target_t >= times.back()) {
+        x = xs.back();
+        y = ys.back();
+      } else {
+        auto upper = std::upper_bound(times.begin(), times.end(), target_t);
+        size_t idx = upper - times.begin();
+        double t1 = times[idx - 1];
+        double t2 = times[idx];
+        double ratio = (target_t - t1) / (t2 - t1);
+        x = xs[idx - 1] + ratio * (xs[idx] - xs[idx - 1]);
+        y = ys[idx - 1] + ratio * (ys[idx] - ys[idx - 1]);
+      }
+
+      if (forward_only_ && x <= 0.0) {
+        x = last_x;
+        y = last_y;
+      } else {
+        last_x = x;
+        last_y = y;
+      }
+
+      if (normalize_) {
+        x /= scan->range_max;
+        y /= scan->range_max;
+      }
+      label_x[i] = x;
+      label_y[i] = y;
+    }
+
+    if (file_.is_open()) {
+      file_ << std::fixed << std::setprecision(6)
+            << rclcpp::Time(scan->header.stamp).seconds();
+      for (double v : scan_vals) {
+        file_ << "," << v;
+      }
+      for (double v : grid_vals) {
+        file_ << "," << v;
+      }
+      for (double v : label_x) {
+        file_ << "," << v;
+      }
+      for (double v : label_y) {
+        file_ << "," << v;
+      }
+      file_ << "\n";
+    }
+  }
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  message_filters::Subscriber<sensor_msgs::msg::LaserScan> scan_sub_;
+  message_filters::Subscriber<sensor_msgs::msg::LaserScan> grid_sub_;
+  message_filters::Subscriber<PathMsg> path_sub_;
+  std::shared_ptr<Synchronizer> sync_;
+
+  std::ofstream file_;
+  double horizon_sec_;
+  double dt_;
+  bool forward_only_;
+  bool normalize_;
+  int downsample_;
+  size_t counter_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<DataLoggerNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/src/tools/global_to_polar_node.cpp
+++ b/src/tools/global_to_polar_node.cpp
@@ -1,0 +1,116 @@
+#include <vector>
+#include <cmath>
+#include <memory>
+#include <algorithm>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "trajectory_msgs/msg/multi_dof_joint_trajectory.hpp"
+#include "tf2/utils.h"
+
+class GlobalToPolarNode : public rclcpp::Node
+{
+public:
+  GlobalToPolarNode()
+  : Node("global_to_polar_node")
+  {
+    path_sub_ = create_subscription<trajectory_msgs::msg::MultiDOFJointTrajectory>(
+      "/planned_path_with_velocity", 10,
+      std::bind(&GlobalToPolarNode::pathCallback, this, std::placeholders::_1));
+    odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
+      "/pf/pose/odom", 10,
+      std::bind(&GlobalToPolarNode::odomCallback, this, std::placeholders::_1));
+    scan_sub_ = create_subscription<sensor_msgs::msg::LaserScan>(
+      "/scan", rclcpp::SensorDataQoS(),
+      std::bind(&GlobalToPolarNode::scanCallback, this, std::placeholders::_1));
+    grid_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
+      "/polar_grid", 10);
+  }
+
+private:
+  void pathCallback(const trajectory_msgs::msg::MultiDOFJointTrajectory::SharedPtr msg)
+  {
+    path_ = *msg;
+  }
+
+  void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    odom_ = *msg;
+    odom_received_ = true;
+  }
+
+  void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan)
+  {
+    if (!odom_received_) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "No odom received yet");
+      return;
+    }
+    if (scan->ranges.size() != 1080) {
+      RCLCPP_WARN(get_logger(), "Scan size %zu not 1080", scan->ranges.size());
+      return;
+    }
+
+    std::vector<float> grid(1080, std::numeric_limits<float>::infinity());
+
+    double robot_x = odom_.pose.pose.position.x;
+    double robot_y = odom_.pose.pose.position.y;
+    double yaw = tf2::getYaw(odom_.pose.pose.orientation);
+
+    for (const auto & pt : path_.points) {
+      if (pt.transforms.empty()) {
+        continue;
+      }
+      const auto & tr = pt.transforms[0].translation;
+      double dx = tr.x - robot_x;
+      double dy = tr.y - robot_y;
+      double rel_angle = std::atan2(dy, dx) - yaw;
+      // normalize angle
+      while (rel_angle > M_PI) rel_angle -= 2.0 * M_PI;
+      while (rel_angle < -M_PI) rel_angle += 2.0 * M_PI;
+      int idx = static_cast<int>(std::round((rel_angle - scan->angle_min) / scan->angle_increment));
+      if (idx >= 0 && idx < 1080) {
+        float dist = std::sqrt(dx * dx + dy * dy);
+        if (!std::isfinite(grid[idx]) || dist < grid[idx]) {
+          grid[idx] = dist;
+        }
+      }
+    }
+
+    for (auto & v : grid) {
+      if (!std::isfinite(v)) {
+        v = 0.0f;
+      }
+    }
+
+    auto msg = sensor_msgs::msg::LaserScan();
+    msg.header.stamp = scan->header.stamp;
+    msg.header.frame_id = "base_link";
+    msg.angle_min = scan->angle_min;
+    msg.angle_max = scan->angle_max;
+    msg.angle_increment = scan->angle_increment;
+    msg.range_min = 0.0;
+    msg.range_max = 100.0;
+    msg.ranges = grid;
+    grid_pub_->publish(msg);
+  }
+
+  trajectory_msgs::msg::MultiDOFJointTrajectory path_;
+  nav_msgs::msg::Odometry odom_;
+  bool odom_received_ {false};
+
+  rclcpp::Subscription<trajectory_msgs::msg::MultiDOFJointTrajectory>::SharedPtr path_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr grid_pub_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GlobalToPolarNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- Add DataLoggerNode to sync scan, polar grid, and planned path, generating CSV labels
- Add GlobalToPolarNode converting global path to laser-style polar grid using odometry
- Expose configurable parameters and launch file for joint execution

## Testing
- `colcon test --packages-select ekf_slam` *(failed: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a083d9b700832093a550c5caa3f17c