### PR TITLE
Use ICP for data association

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME}_lib
   src/core/slam_system.cpp
   src/preprocessing/laser_processor.cpp
   src/association/data_association.cpp
+  src/association/icp.cpp
   src/mapping/occupancy_mapper.cpp
 )
 

--- a/include/association/icp.hpp
+++ b/include/association/icp.hpp
@@ -1,0 +1,26 @@
+#ifndef EKF_SLAM_ICP_HPP
+#define EKF_SLAM_ICP_HPP
+
+#include <Eigen/Dense>
+#include <vector>
+
+namespace ekf_slam {
+
+struct ICPResult {
+  Eigen::Matrix2d R; // rotation
+  Eigen::Vector2d t; // translation
+  std::vector<int>
+      correspondences;        // index of matched target for each source point
+  std::vector<double> errors; // squared distances for each source point
+};
+
+// Simple 2D point-to-point ICP implementation.
+// Aligns source points to target points and returns the final transform and
+// correspondences.
+ICPResult runICP(const std::vector<Eigen::Vector2d> &src,
+                 const std::vector<Eigen::Vector2d> &dst,
+                 int max_iterations = 20, double tolerance = 1e-6);
+
+} // namespace ekf_slam
+
+#endif // EKF_SLAM_ICP_HPP

--- a/src/association/data_association.cpp
+++ b/src/association/data_association.cpp
@@ -1,71 +1,67 @@
 #include "association/data_association.hpp"
+#include "association/icp.hpp"
 #include "preprocessing/laser_processor.hpp"
+#include <Eigen/Geometry>
 #include <cmath>
 #include <limits>
 
 namespace ekf_slam {
 
 DataAssociation::DataAssociation(double mahalanobis_thresh, double ratio_thresh)
-: threshold_(mahalanobis_thresh), ratio_thresh_(ratio_thresh) {}
+    : threshold_(mahalanobis_thresh), ratio_thresh_(ratio_thresh) {}
 
 int DataAssociation::associate(
-    const laser::Observation& obs,
-    const Eigen::VectorXd& mu,
-    const Eigen::MatrixXd& sigma,
-    const std::unordered_map<int, int>& landmark_index_map,
-    const Eigen::Matrix2d& Q)
-{
-    double min_dist = std::numeric_limits<double>::infinity();
-    double second_min = std::numeric_limits<double>::infinity();
-    int matched_id = -1;
+    const laser::Observation &obs, const Eigen::VectorXd &mu,
+    const Eigen::MatrixXd & /*sigma*/,
+    const std::unordered_map<int, int> &landmark_index_map,
+    const Eigen::Matrix2d & /*Q*/) {
+  // Transform observation to world coordinates
+  double rx = mu(0);
+  double ry = mu(1);
+  double theta = mu(2);
+  Eigen::Vector2d obs_local(obs.range * std::cos(obs.bearing),
+                            obs.range * std::sin(obs.bearing));
+  Eigen::Rotation2Dd rot(theta);
+  Eigen::Vector2d obs_world = rot * obs_local + Eigen::Vector2d(rx, ry);
 
-    for (const auto& [landmark_id, idx] : landmark_index_map) {
-        double lx = mu(idx);
-        double ly = mu(idx + 1);
-        double rx = mu(0);
-        double ry = mu(1);
-        double theta = mu(2);
+  // Prepare target landmarks
+  std::vector<Eigen::Vector2d> landmarks;
+  std::vector<int> ids;
+  for (const auto &[landmark_id, idx] : landmark_index_map) {
+    landmarks.emplace_back(mu(idx), mu(idx + 1));
+    ids.push_back(landmark_id);
+  }
 
-        double dx = lx - rx;
-        double dy = ly - ry;
-        double q = dx * dx + dy * dy;
-        double sqrt_q = std::sqrt(q);
+  // Run ICP between observation point and map landmarks
+  std::vector<Eigen::Vector2d> src{obs_world};
+  ICPResult icp_res = runICP(src, landmarks, 10, 1e-6);
 
-        Eigen::Vector2d z_pred(sqrt_q, std::atan2(dy, dx) - theta);
-        Eigen::Vector2d z_obs(obs.range, obs.bearing);
-        Eigen::Vector2d innovation = z_obs - z_pred;
-
-        Eigen::Matrix<double, 2, 5> H;
-        H << -sqrt_q * dx / q, -sqrt_q * dy / q, 0,  sqrt_q * dx / q,  sqrt_q * dy / q,
-              dy / q,         -dx / q,         -1, -dy / q,           dx / q;
-
-        Eigen::MatrixXd Sigma_x = Eigen::MatrixXd::Zero(5, 5);
-        Sigma_x.block<3,3>(0,0) = sigma.block<3,3>(0,0);
-        Sigma_x.block<3,2>(0,3) = sigma.block(0, idx, 3, 2);
-        Sigma_x.block<2,3>(3,0) = sigma.block(idx, 0, 2, 3);
-        Sigma_x.block<2,2>(3,3) = sigma.block(idx, idx, 2, 2);
-
-        Eigen::Matrix2d S = H * Sigma_x * H.transpose() + Q;
-
-        double dist = innovation.transpose() * S.inverse() * innovation;
-        if (dist < min_dist) {
-            second_min = min_dist;
-            min_dist = dist;
-            matched_id = landmark_id;
-        } else if (dist < second_min) {
-            second_min = dist;
-        }
-    }
-
-    double ratio = min_dist / second_min;
-    if (second_min == std::numeric_limits<double>::infinity()) {
-        ratio = 0.0; // only one landmark candidate
-    }
-
-    if (min_dist < threshold_ && ratio < ratio_thresh_) {
-        return matched_id;
-    }
+  if (icp_res.correspondences.empty() || icp_res.correspondences[0] < 0) {
     return -1;
+  }
+
+  double min_dist = icp_res.errors[0];
+  int matched_idx = icp_res.correspondences[0];
+
+  double second_min = std::numeric_limits<double>::infinity();
+  for (std::size_t j = 0; j < landmarks.size(); ++j) {
+    if (static_cast<int>(j) == matched_idx)
+      continue;
+    double d = (obs_world - landmarks[j]).squaredNorm();
+    if (d < second_min) {
+      second_min = d;
+    }
+  }
+
+  double ratio = min_dist / second_min;
+  if (second_min == std::numeric_limits<double>::infinity()) {
+    ratio = 0.0; // only one landmark candidate
+  }
+
+  if (min_dist < threshold_ && ratio < ratio_thresh_) {
+    return ids[matched_idx];
+  }
+  return -1;
 }
 
-}  // namespace ekf_slam
+} // namespace ekf_slam

--- a/src/association/icp.cpp
+++ b/src/association/icp.cpp
@@ -1,0 +1,85 @@
+#include "association/icp.hpp"
+#include <limits>
+
+namespace ekf_slam {
+
+ICPResult runICP(const std::vector<Eigen::Vector2d> &src,
+                 const std::vector<Eigen::Vector2d> &dst, int max_iterations,
+                 double tolerance) {
+  ICPResult result;
+  result.R.setIdentity();
+  result.t.setZero();
+  result.correspondences.assign(src.size(), -1);
+  result.errors.assign(src.size(), std::numeric_limits<double>::infinity());
+
+  if (src.empty() || dst.empty()) {
+    return result;
+  }
+
+  Eigen::Matrix2d R = Eigen::Matrix2d::Identity();
+  Eigen::Vector2d t = Eigen::Vector2d::Zero();
+  double prev_error = std::numeric_limits<double>::max();
+
+  for (int iter = 0; iter < max_iterations; ++iter) {
+    // Find correspondences
+    double total_error = 0.0;
+    std::vector<Eigen::Vector2d> src_matched(src.size());
+    std::vector<Eigen::Vector2d> dst_matched(src.size());
+
+    for (std::size_t i = 0; i < src.size(); ++i) {
+      Eigen::Vector2d p = R * src[i] + t;
+      double best = std::numeric_limits<double>::infinity();
+      int best_idx = -1;
+      for (std::size_t j = 0; j < dst.size(); ++j) {
+        double dist = (p - dst[j]).squaredNorm();
+        if (dist < best) {
+          best = dist;
+          best_idx = static_cast<int>(j);
+        }
+      }
+      src_matched[i] = src[i];
+      dst_matched[i] = dst[best_idx];
+      result.correspondences[i] = best_idx;
+      result.errors[i] = best;
+      total_error += best;
+    }
+
+    double mean_error = total_error / src.size();
+    if (std::abs(prev_error - mean_error) < tolerance) {
+      break;
+    }
+    prev_error = mean_error;
+
+    // Compute centroids
+    Eigen::Vector2d centroid_src = Eigen::Vector2d::Zero();
+    Eigen::Vector2d centroid_dst = Eigen::Vector2d::Zero();
+    for (std::size_t i = 0; i < src_matched.size(); ++i) {
+      centroid_src += src_matched[i];
+      centroid_dst += dst_matched[i];
+    }
+    centroid_src /= static_cast<double>(src_matched.size());
+    centroid_dst /= static_cast<double>(dst_matched.size());
+
+    // Compute covariance matrix
+    Eigen::Matrix2d W = Eigen::Matrix2d::Zero();
+    for (std::size_t i = 0; i < src_matched.size(); ++i) {
+      W += (src_matched[i] - centroid_src) *
+           (dst_matched[i] - centroid_dst).transpose();
+    }
+
+    // SVD for rotation
+    Eigen::JacobiSVD<Eigen::Matrix2d> svd(W, Eigen::ComputeFullU |
+                                                 Eigen::ComputeFullV);
+    Eigen::Matrix2d R_iter = svd.matrixV() * svd.matrixU().transpose();
+    Eigen::Vector2d t_iter = centroid_dst - R_iter * centroid_src;
+
+    R = R_iter * R;
+    t = R_iter * t + t_iter;
+  }
+
+  result.R = R;
+  result.t = t;
+  return result;
+}
+
+} // namespace ekf_slam


### PR DESCRIPTION
## Summary
- add simple ICP utilities
- switch data association to ICP-based matching

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*
- `cmake ..` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a54584d20c8320841538a6ed354391