### PR TITLE
Print RMSE and highlight max error in ATE evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 The package provides a simple script to compare the SLAM trajectory with the
 simulation ground truth. The node listens to `/odom` for ground truth and
 `/slam_odom` published by `slam_node` and computes the Absolute Trajectory Error
-root mean square error (RMSE). A plot comparing both trajectories is saved to
+root mean square error (RMSE). The evaluator prints the RMSE and reports the
+time step with the maximum error. These metrics are also written to
+`ate_metrics.txt`. A smoothed plot comparing both trajectories is saved to
 `trajectory_comparison.png`.
 
 Run the evaluator after launching the SLAM node:


### PR DESCRIPTION
## Summary
- print RMSE and log/write it to `ate_metrics.txt`
- report time and positions of max error
- smooth plotted trajectories with cubic spline

## Testing
- `python -m py_compile scripts/compute_ate.py`
- `python scripts/compute_ate.py --help` *(fails: ModuleNotFoundError: No module named 'rclpy')*
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a4e758483209811418fefb6c585