### PR TITLE
Use node clock for occupancy mapper timestamps

### DIFF
--- a/src/mapping/occupancy_mapper.cpp
+++ b/src/mapping/occupancy_mapper.cpp
@@ -87,7 +87,7 @@ void OccupancyMapper::addScanData(const Eigen::Vector3d &robot_pose,
   OccupancyScanData data;
   data.robot_pose = robot_pose;
   data.scan = scan;
-  data.timestamp = rclcpp::Clock().now();
+  data.timestamp = node_->get_clock()->now();
 
   data_queue_.push(data);
   queue_cv_.notify_one();
@@ -263,7 +263,7 @@ nav_msgs::msg::OccupancyGrid OccupancyMapper::getOccupancyGrid() const {
   nav_msgs::msg::OccupancyGrid grid;
 
   // 헤더 설정
-  grid.header.stamp = rclcpp::Clock().now();
+  grid.header.stamp = node_->get_clock()->now();
   grid.header.frame_id = "map";
 
   // 맵 정보 설정


### PR DESCRIPTION
## Summary
- Use `node_->get_clock()` instead of `rclcpp::Clock` for scan data and grid header timestamps

## Testing
- `colcon test --packages-select ekf_slam` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b2671d148320809c759062ab4483